### PR TITLE
Initial commit for image build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+FROM debian:bullseye
+
+# Puppet version data from Makefile
+ARG PUPPET_VERSION_MAJOR
+
+# 1. Install Puppetserver packages.
+# 2. Create /etc/puppetlabs/puppetserver/ca-tls where we will use for a bind mount containing TLS certs.
+# 3. Configure Puppet to use the CA cert/key from the location in #2.
+RUN apt-get update && apt-get install wget -y && \
+  wget http://apt.puppetlabs.com/puppet${PUPPET_VERSION_MAJOR}-release-bullseye.deb && \
+  dpkg -i puppet${PUPPET_VERSION_MAJOR}-release-bullseye.deb && \
+  apt-get update && apt-get install sudo vim curl git puppetserver -y && \
+  rm puppet${PUPPET_VERSION_MAJOR}-release-bullseye.deb && \
+  mkdir /etc/puppetlabs/puppetserver/ca-tls && \
+  /opt/puppetlabs/puppet/bin/puppet config set --section server cacert /etc/puppetlabs/puppetserver/ca-tls/tls.crt && \
+  /opt/puppetlabs/puppet/bin/puppet config set --section server cakey /etc/puppetlabs/puppetserver/ca-tls/tls.key
+
+EXPOSE 8140
+
+# Do we need to start a puppetserver foreground instance when running the container?
+# USER puppet
+# CMD ["/opt/puppetlabs/server/bin/puppetserver", "foreground"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,19 @@
+PUPPET_VERSION_MAJOR := 7
+
+DOCKER_IMAGE_NAME := oi_puppetserver
+DOCKER_IMAGE_TAG_VERSION := 1.0.0
+
+.PHONY: build-image
+build-image:
+	$(info Building image for Puppet major version "$(PUPPET_VERSION_MAJOR)")
+	docker build \
+		--build-arg PUPPET_VERSION=${PUPPET_VERSION} \
+		--build-arg PUPPET_VERSION_MAJOR=${PUPPET_VERSION_MAJOR} \
+		-t ${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG_VERSION} .
+
+.PHONY: docker-run
+docker-run:
+	docker run --rm -it \
+	-v $(CURDIR):/workspace \
+	${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG_VERSION} \
+	/bin/bash

--- a/README.md
+++ b/README.md
@@ -1,2 +1,39 @@
-# docker-puppetserver
-Docker container for running a Puppetserver instance
+# Puppetserver Docker Image
+
+This repository manages the Docker image that we use for spinning up
+a Puppetserver instance.
+
+## Building the image
+
+*The make and docker executables must be installed to build the image.*
+
+The [Makefile](./Makefile) includes a `build-image` target that abstracts the
+commands necessary to build the image:
+
+```bash
+❯ make build-image
+Building image for Puppet version ""
+docker build \
+                --build-arg PUPPET_VERSION= \
+                --build-arg PUPPET_VERSION_MAJOR=7 \
+                -t oi_puppetserver:1.0.0 .
+[+] Building 82.0s (7/7) FINISHED
+<...>
+```
+
+## Running the container locally
+
+The [Makefile](./Makefile) includes a `docker-run` target that abstracts the
+commands necessary to run an instance of the container locally:
+
+```bash
+❯ make docker-run
+docker run --rm -it \
+        -v /Users/glarizza/src/oi/docker-puppetserver:/workspace \
+        oi_puppetserver:1.0.0 \
+        /bin/bash
+root@466439a997b2:/#
+```
+
+NOTE: The repository root is mounted at `/workspace` to allow for copying files
+to/from the running container.


### PR DESCRIPTION
PROBLEM:

In order to test out a Vault authentication workflow that includes
Puppet certificates, we need the ability to quickly spin up
a Puppetserver. Having a Docker image for a Puppetserver serves that
need. We're also not interested in using the Puppet-in-Docker
"Pupperware" solution because it's overly complex for what we need.

SOLUTION:

Create a `Dockerfile` for a Debian Docker image that installs
the Puppet/Puppetserver packages and maps the `cakey` and `cacert`
options to the CA cert/key that we've specified.

OUTCOME:

We're able to quickly spin up a Puppetserver instance with our provided
CA cert/key.
